### PR TITLE
chore: move CODEOWNERS + add entry for .github/agents

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @ContentSquare/mobile-react-native
+
+# Protect .github/agents folder for GitHub Copilot agents
+/.github/agents/ @ContentSquare/mobile-react-native

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ContentSquare/mobile-react-native


### PR DESCRIPTION
## Description
Add a CODEOWNERS entry to protect the `.github/agents/` folder

## Motivation and Context
Proactively protect the GitHub agents folder so that when GitHub Copilot agent configurations are added, they will require review from the repository owners.

## Breaking Changes
No

## How Has This Been Tested?
N/A - CODEOWNERS configuration change only