### PR TITLE
chore: update Codeowners for mobile teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @ContentSquare/mobile-react-native
+* @ContentSquare/react-native
 
 # Protect .github/agents folder for GitHub Copilot agents
-/.github/agents/ @ContentSquare/mobile-react-native
+/.github/agents/ @ContentSquare/react-native


### PR DESCRIPTION
## Context
Github Unit team enforcement
- [Slack communication](https://contentsquare.slack.com/archives/C01E9UNEC0Z/p1777909600643489?thread_ts=1775573484.522699&cid=C01E9UNEC0Z)
- [Documentation](https://next-docs.csquad.io/platform/github/teams/)

### What was done
Replace legacy github teams by terraform managed team, following:
- `mobile-capture` -> `sdk-capture`
- `mobile-flutter` -> `flutter`
- `mobile-react-native` -> `react-native`
- `mobile_core-android` -> `sdk-native-core-android`
- `mobile_core-ios` -> `sdk-native-core-ios`
- `mobile_errors-and-surveys` -> `sdk-errors-and-surveys`
- `mobile_errors-and-surveys-android` -> `sdk-errors-and-surveys-android`
- `mobile_errors-and-surveys-ios` -> `sdk-errors-and-surveys-ios`
- `mobile_native-core` -> `sdk-native-core`
- `mobile_screen-insights` -> `sdk-screen-insights`
- `mobile_screen-insights-android` -> `sdk-screen-insights-android`
- `mobile_screen-insights-ios` -> `sdk-screen-insights-ios`
- `mobile_session-replay` -> `sdk-session-replay-and-errors`
- `mobile_session-replay-android` -> `sdk-session-replay-and-errors-android`
- `mobile_session-replay-flutter` -> `sdk-session-replay-and-errors-flutter`
- `mobile_session-replay-ios` -> `sdk-session-replay-and-errors-ios`
- `mobile_xpf-core` -> `sdk-cross-platform-core`